### PR TITLE
.gitignore for Pathogen-generated doc/tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Hi, thanks for making this plugin - I've just rebound my default w, b and e motions and it's really handy!

Would you consider adding this .gitignore to the repo?  It makes it easier to use with Pathogen via git submodule - otherwise when Pathogen generates the helptags file git flags the submodule as modified.
## Cheers!

Sam
