### PR TITLE
updated markdown code syntax, Vundle instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ for identifiers. The best way to navigate inside those identifiers using Vim
 built-in motions is the [count]f{char} motion, i.e. f{uppercase-char} or f\_,
 respectively. But we can make this easier:
 
-This script defines motions ',w', ',b' and ',e' (similar to 'w', 'b', 'e'),
+This script defines motions `,w`, `,b` and `,e` (similar to `w`, `b`, `e`),
 which do not move word-wise (forward/backward), but Camel-wise; i.e. to word
 boundaries and uppercase letters. The motions also work on underscore notation,
 where words are delimited by underscore ('_') characters. From here on, both
@@ -22,15 +22,15 @@ quotes). Just like with the regular motions, a [count] can be prepended to move
 over multiple "words" at once. Outside of "words" (e.g. in non-keyword
 characters like // or ;), the new motions move just like the regular motions.
 
-Vim provides a built-in 'iw' text object called 'inner word', which works in
+Vim provides a built-in `iw` text object called 'inner word', which works in
 operator-pending and visual mode. Analog to that, this script defines inner
-"word" motions 'i,w', 'i,b' and 'i,e', which select the "word" (or multiple
+"word" motions `i,w`, `i,b` and `i,e`, which select the "word" (or multiple
 "words" if a [count] is given) where the cursor is located.
 
 Usage
 ======
-Use the new motions ',w', ',b' and ',e' in normal mode, operator-pending mode (cp.
-:help operator), and visual mode. For example, type 'bc,w' to change 'Camel' in
+Use the new motions `,w`, `,b` and `,e` in normal mode, operator-pending mode (cp.
+:help operator), and visual mode. For example, type `bc,w` to change 'Camel' in
 'CamelCase' to something else.
 
 **Motions Example**
@@ -45,12 +45,12 @@ and the corresponding identifiers in underscore_notation::
     set script_31337_path_and_name_without_extension_11=%~dpn0
     set SCRIPT_31337_PATH_AND_NAME_WITHOUT_EXTENSION_11=%~dpn0
 
-,w moves to ([x] is cursor position): [s]et, [s]cript, [3]1337, [p]ath,
+`,w` moves to ([x] is cursor position): [s]et, [s]cript, [3]1337, [p]ath,
 [a]nd, [n]ame, [w]ithout, [e]xtension, [1]1, [d]pn0, dpn[0], [s]et
 
-,b moves to: [d]pn0, [1]1, [e]xtension, [w]ithout, ...
+`,b` moves to: [d]pn0, [1]1, [e]xtension, [w]ithout, ...
 
-,e moves to: se[t], scrip[t], 3133[7], pat[h], an[d], nam[e], withou[t],
+`,e` moves to: se[t], scrip[t], 3133[7], pat[h], an[d], nam[e], withou[t],
 extensio[n], 1[1], dpn[0]
 
 **Inner Motions Example**
@@ -58,14 +58,14 @@ Given the following identifier, with the cursor positioned at [x]::
 
     script_31337_path_and_na[m]e_without_extension_11
 
-v3i,w selects script_31337_path_and_[name_without_extension\_]11
+`v3i,w` selects script_31337_path_and_[name_without_extension\_]11
 
-v3i,b selects script_31337_[path_and_name]_without_extension_11
+`v3i,b` selects script_31337_[path_and_name]_without_extension_11
 
-v3i,e selects script_31337_path_and_[name_without_extension]_11
+`v3i,e` selects script_31337_path_and_[name_without_extension]_11
 
-Instead of visual mode, you can also use c3i,w to change, d3i,w to delete,
-gU3i,w to upper-case, and so on.
+Instead of visual mode, you can also use `c3i,w` to change, `d3i,w` to delete,
+`gU3i,w` to upper-case, and so on.
 
 **Source**
 
@@ -73,6 +73,16 @@ Based on http://vim.wikia.com/wiki/Moving_through_camel_case_words by Anthony Va
 
 Installation
 =============
+
+With a plugin manager
+---------------------
+
+Use standard approach. For example, for [Vundle](https://github.com/VundleVim/Vundle.vim),
+just add `Plugin 'bkad/CamelCaseMotion'` to your .vimrc and run `:PluginInstall`.
+
+With vimball script
+-------------------
+
 This script is packaged as a vimball. If you have the "gunzip" decompressor
 in your PATH, simply edit the \*.vba.gz package in Vim; otherwise, decompress
 the archive first, e.g. using WinZip. Inside Vim, install by sourcing the
@@ -85,11 +95,13 @@ vimball or via the ``:UseVimball`` command.
 
 To uninstall, use the ``:RmVimball`` command.
 
-**Dependencies**
+Dependencies
+------------
 
 Requires Vim 7.0 or higher.
 
-**Configuration**
+Configuration
+-------------
 
 If you want to use different mappings, map your keys to the
 ``<Plug>CamelCaseMotion_?`` mapping targets _before_ sourcing this script (e.g. in


### PR DESCRIPTION
I added instructions that a plugin-manager works, changed some headers,
and made the commands clearer via actual markdown code syntax instead of just quotes