### PR TITLE
Changed from comma prefix (,w) to mapleader (<leader>w).

### DIFF
--- a/doc/camelcasemotion.txt
+++ b/doc/camelcasemotion.txt
@@ -20,27 +20,31 @@ for identifiers. The best way to navigate inside those identifiers using Vim
 built-in motions is the [count]f{char} motion, i.e. f{uppercase-char} or f_,
 respectively. But we can make this easier: 
 
-This script defines motions |,w|, |,b| and |,e| (similar to |w|, |b|, |e|),
-which do not move word-wise (forward/backward), but Camel-wise; i.e.  to
-word boundaries and uppercase letters. The motions also work on underscore
-notation, where words are delimited by underscore ('_') characters. From
-here on, both CamelCase and underscore_notation entities are referred to as
-"words" (in double quotes). Just like with the regular motions, a [count]
-can be prepended to move over multiple "words" at once. Outside of "words"
-(e.g. in non-keyword characters like // or ;), the new motions move just
-like the regular motions. 
+This script defines motions |<leader>w|, |<leader>b| and |<leader>e| (similar
+to |w|, |b|, |e|), which do not move word-wise (forward/backward), but
+Camel-wise; i.e.  to word boundaries and uppercase letters. The motions also
+work on underscore notation, where words are delimited by underscore ('_')
+characters. From here on, both CamelCase and underscore_notation entities are
+referred to as "words" (in double quotes). Just like with the regular motions,
+a [count] can be prepended to move over multiple "words" at once. Outside of
+"words" (e.g. in non-keyword characters like // or ;), the new motions move
+just like the regular motions. 
 
 Vim provides a built-in |iw| text object called 'inner word', which works in
 operator-pending and visual mode. Analoguous to that, this script defines
-inner "word" motions |i,w|, |i,b| and |i,e|, which select the "word" (or
-multiple "words" if a [count] is given) where the cursor is located. 
+inner "word" motions |i<leader>w|, |i<leader>b| and |i<leader>e|, which select
+the "word" (or multiple "words" if a [count] is given) where the cursor is
+located. 
 
 ==============================================================================
 USAGE						       *camelcasemotion-usage*
-								*,w* *,b* *,e*
-Use the new motions |,w|, |,b| and |,e| in normal mode, operator-pending
-mode (cf. |operator|), and visual mode. For example, if the cursor is on the
-'m', type 'bc,w' to change 'Camel' in 'CamelCase' to something else. 
+                                                                *<leader>w*
+                                                                *<leader>b*
+                                                                *<leader>e*
+Use the new motions |<leader>w|, |<leader>b| and |<leader>e| in normal mode,
+operator-pending mode (cf. |operator|), and visual mode. For example, if the
+cursor is on the 'm', type 'bc<leader>w' to change 'Camel' in 'CamelCase' to
+something else. 
 
 
 EXAMPLE: motions
@@ -51,22 +55,22 @@ and the corresponding identifiers in underscore_notation:
     set script_31337_path_and_name_without_extension_11=%~dpn0 ~
     set SCRIPT_31337_PATH_AND_NAME_WITHOUT_EXTENSION_11=%~dpn0 ~
 
-,w moves to ([x] is cursor position): [s]et, [s]cript, [3]1337, [p]ath,
+<leader>w moves to ([x] is cursor position): [s]et, [s]cript, [3]1337, [p]ath,
     [a]nd, [n]ame, [w]ithout, [e]xtension, [1]1, [d]pn0, dpn[0], [s]et
-,b moves to: [d]pn0, [1]1, [e]xtension, [w]ithout, ...
-,e moves to: se[t], scrip[t], 3133[7], pat[h], an[d], nam[e], withou[t],
-    extensio[n], 1[1], dpn[0]
+<leader>b moves to: [d]pn0, [1]1, [e]xtension, [w]ithout, ...
+<leader>e moves to: se[t], scrip[t], 3133[7], pat[h], an[d], nam[e],
+    withou[t], extensio[n], 1[1], dpn[0]
 
 
 EXAMPLE: inner motions
 Given the following identifier, with the cursor positioned at [x]:
     script_31337_path_and_na[m]e_without_extension_11 ~
 
-v3i,w selects script_31337_path_and_[name_without_extension_]11
-v3i,b selects script_31337_[path_and_name]_without_extension_11
-v3i,e selects script_31337_path_and_[name_without_extension]_11
-Instead of visual mode, you can also use c3i,w to change, d3i,w to delete,
-gU3i,w to upper-case, and so on. 
+v3i<leader>w selects script_31337_path_and_[name_without_extension_]11
+v3i<leader>b selects script_31337_[path_and_name]_without_extension_11
+v3i<leader>e selects script_31337_path_and_[name_without_extension]_11
+Instead of visual mode, you can also use c3i<leader>w to change, d3i<leader>w
+to delete, gU3i<leader>w to upper-case, and so on. 
 
 ==============================================================================
 INSTALLATION					*camelcasemotion-installation*
@@ -91,7 +95,7 @@ If you want to use different mappings, map your keys to the
 your |vimrc|).  
 
 EXAMPLE: Replace the default |w|, |b| and |e| mappings instead of defining
-additional mappings |,w|, |,b| and |,e|: >
+additional mappings |<leader>w|, |<leader>b| and |<leader>e|: >
     map <silent> w <Plug>CamelCaseMotion_w
     map <silent> b <Plug>CamelCaseMotion_b
     map <silent> e <Plug>CamelCaseMotion_e
@@ -111,18 +115,19 @@ EXAMPLE: Replace default |iw| text-object and define |ib| and |ie| motions: >
 KNOWN PROBLEMS				      *camelcasemotion-known-problems*
 
 - A degenerate CamelCaseWord containing '\U\u\d' (e.g. "MaP1Roblem") confuses
-  the operator-pending and visual mode ,e mapping if 'selection' is not set to
-  "exclusive". It'll skip "P" and select "P1" in one step. As a workaround,
-  use |,w| instead of |,e|; those two mappings have the same effect inside
-  CamelCaseWords, anyway. 
-- The operator-pending and visual mode |,e| mapping doesn't work properly when
-  it reaches the end of the buffer; the final character of the moved-over
-  "word" remains. As a workaround, use the default 'e' motion instead of ',e'. 
+  the operator-pending and visual mode <leader>e mapping if 'selection' is not
+  set to "exclusive". It'll skip "P" and select "P1" in one step. As a
+  workaround, use |<leader>w| instead of |<leader>e|; those two mappings have
+  the same effect inside CamelCaseWords, anyway. 
+- The operator-pending and visual mode |<leader>e| mapping doesn't work
+  properly when it reaches the end of the buffer; the final character of the
+  moved-over "word" remains. As a workaround, use the default 'e' motion
+  instead of '<leader>e'. 
 - When the Vim setting 'selection' is not set to "exclusive", a
-  forward-backward combination in visual mode (e.g. 'v,w,b') selects one
-  additional character to the left, instead of only the character where the
-  motion started. Likewise, extension of the visual selection from the front
-  end is off by one additional character. 
+  forward-backward combination in visual mode (e.g. 'v<leader>w<leader>b')
+  selects one additional character to the left, instead of only the character
+  where the motion started. Likewise, extension of the visual selection from
+  the front end is off by one additional character. 
 
 ==============================================================================
 TODO							*camelcasemotion-todo*

--- a/plugin/camelcasemotion.vim
+++ b/plugin/camelcasemotion.vim
@@ -159,7 +159,7 @@ function! s:CreateMotionMappings()
 	    let l:targetMapping = '<Plug>CamelCaseMotion_' . l:motion
 	    execute l:mode . 'noremap <silent> ' . l:targetMapping . ' :<C-U>call camelcasemotion#Motion(''' . l:motion . ''',v:count1,''' . l:mode . ''')<CR>'
 	    if ! hasmapto(l:targetMapping, l:mode)
-		execute (l:mode ==# 'v' ? 'x' : l:mode) . 'map <silent> ,' . l:motion . ' ' . l:targetMapping 
+		execute (l:mode ==# 'v' ? 'x' : l:mode) . 'map <silent> <leader>' . l:motion . ' ' . l:targetMapping 
 	    endif
 	endfor
     endfor
@@ -189,7 +189,7 @@ function! s:CreateInnerMotionMappings()
 	    let l:targetMapping = '<Plug>CamelCaseMotion_i' . l:motion
 	    execute l:mode . 'noremap <silent> ' . l:targetMapping . ' :<C-U>call camelcasemotion#InnerMotion(''' . l:motion . ''',v:count1)<CR>'
 	    if ! hasmapto(l:targetMapping, l:mode)
-		execute (l:mode ==# 'v' ? 'x' : l:mode) . 'map <silent> i,' . l:motion . ' ' . l:targetMapping 
+		execute (l:mode ==# 'v' ? 'x' : l:mode) . 'map <silent> i<leader>' . l:motion . ' ' . l:targetMapping 
 	    endif
 	endfor
     endfor


### PR DESCRIPTION
Using `<leader>` allows users to use this plugin like they would any other custom mappings.

I know that a lot of people use the comma as their mapleader anyway, so this won't change anything for them (which is why this change makes sense), but it also lets the rest of us have a sensible out-of-the-box configuration.