### PR TITLE
Prevents some characters being included when doing iw

### DIFF
--- a/autoload/camelcasemotion.vim
+++ b/autoload/camelcasemotion.vim
@@ -42,6 +42,7 @@ call add(s:forward_to_next_list, '\u@<!\u+')                       " ALLCAPS
 call add(s:forward_to_next_list, '[\-_]\zs%(\u\+|\u\l+|\l+|\d+)')  " underscored followed by ALLCAPS, CamelCase, lowercase, or number
 call add(s:forward_to_next_list, '\,')
 call add(s:forward_to_next_list, '\n')
+call add(s:forward_to_next_list, '\s')
 let s:forward_to_next = '\v' . join(s:forward_to_next_list, '|')
 
 function! s:Move(direction, count, mode)

--- a/autoload/camelcasemotion.vim
+++ b/autoload/camelcasemotion.vim
@@ -40,6 +40,8 @@ call add(s:forward_to_next_list, '\u+\zs%(\u\l|\d)')               " ALLCAPS fol
 call add(s:forward_to_next_list, '\u\l+')                          " CamelCase
 call add(s:forward_to_next_list, '\u@<!\u+')                       " ALLCAPS
 call add(s:forward_to_next_list, '[\-_]\zs%(\u\+|\u\l+|\l+|\d+)')  " underscored followed by ALLCAPS, CamelCase, lowercase, or number
+call add(s:forward_to_next_list, '\,')
+call add(s:forward_to_next_list, '\n')
 let s:forward_to_next = '\v' . join(s:forward_to_next_list, '|')
 
 function! s:Move(direction, count, mode)


### PR DESCRIPTION
I'm sure there's a better way to do this but for me right now this works. 

Adds comma, space, and newline to list of regex to watch out for. Fixes https://github.com/bkad/CamelCaseMotion/issues/17