### PR TITLE
Fix W23: Clipboard register not available, using register 0

### DIFF
--- a/autoload/camelcasemotion.vim
+++ b/autoload/camelcasemotion.vim
@@ -218,9 +218,6 @@ function! camelcasemotion#CreateMotionMappings(leader)
             \ 'map <silent> i' . a:leader . l:motion . ' ' . l:targetMapping
     endfor
   endfor
-  if &foldopen =~# 'hor\|all'
-    normal! zv
-  endif
 endfunction
 
 " vim: set sts=2 sw=2 expandtab ff=unix fdm=syntax :


### PR DESCRIPTION
It is meaningless to run `zv` when creating mappings and `zv` causes W23 as of patch 9.1.0852 even though Vim is compiled with clipboard support.