### PR TITLE
Consider punctuation when moving forward

### DIFF
--- a/autoload/camelcasemotion.vim
+++ b/autoload/camelcasemotion.vim
@@ -32,6 +32,8 @@ let s:forward_to_next_list = []
 call add(s:forward_to_next_list, '<\D')                            " word
 call add(s:forward_to_next_list, '^$')                             " empty line
 call add(s:forward_to_next_list, '%(^|\s)+\zs\k@!\S')              " non-keyword after whitespaces
+call add(s:forward_to_next_list, '>\zs\k@!\S')                     " punctuation right after a word  10/22/2025 Strike-F8
+call add(s:forward_to_next_list, '\k@!\S\ze<')                     " punctuation right before a word 10/22/2025 Strike-F8
 call add(s:forward_to_next_list, '><')                             " non-whitespace after word
 call add(s:forward_to_next_list, '[\{\}\[\]\(\)\<\>\&"'."'".']')   " brackets, parens, braces, quotes
 call add(s:forward_to_next_list, '\d+')                            " number


### PR DESCRIPTION
Adding these two entries to `forward_to_next_list` should cause forward motion to additionally stop at punctuation just like vim default behavior. This prevents the occasional undesired behavior of consuming punctuation when using `dw` or `cw`.

Tested using Neovim v0.11.4.

I am not good with regex so I asked ChatGPT to create these two lines for me. It seems to be working but I'm sure there are cases I haven't tested.